### PR TITLE
#10 당일 예약 기능 & 예약 취소 기능 구현(DB상 hard delete)

### DIFF
--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/controller/ReservationController.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/controller/ReservationController.java
@@ -22,4 +22,18 @@ public class ReservationController {
         Reservation reservation = reservationService.scheduleReservation(dto);
         return new ResponseEntity<>(reservation, HttpStatus.OK);
     }
+
+    @GetMapping("/immediate")
+    public ResponseEntity<?> treatImmediateReservation(@RequestBody ReservationSaveReqDto dto){
+        Reservation reservation = reservationService.immediateReservation(dto);
+        return new ResponseEntity<>(reservation, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/cancel/{id}")
+    public ResponseEntity<?> cancelledReservation(@PathVariable Long id){
+        reservationService.cancelledReservation(id);
+
+        return new ResponseEntity<>(null, HttpStatus.OK);
+    }
+
 }

--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/domain/MedicalItem.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/domain/MedicalItem.java
@@ -1,0 +1,6 @@
+package com.padaks.todaktodak.reservation.domain;
+
+public enum MedicalItem{
+    일반진료,
+    예방접종
+}

--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/domain/Reservation.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/domain/Reservation.java
@@ -46,17 +46,10 @@ public class Reservation extends BaseTimeEntity {
     private String doctorEmail;
 
     private ReserveType reservationType;
-    @Column(nullable = false)
     private LocalDate reservationDate;
-    @Column(nullable = false)
     private LocalTime reservationTime;
     private boolean isUntact;
     private Status status;
-
-    public enum MedicalItem{
-        일반진료,
-        예방접종
-    }
     private MedicalItem medicalItem;
 //    증상
     private String field;

--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/dto/ReservationSaveReqDto.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/dto/ReservationSaveReqDto.java
@@ -1,5 +1,6 @@
 package com.padaks.todaktodak.reservation.dto;
 
+import com.padaks.todaktodak.reservation.domain.MedicalItem;
 import com.padaks.todaktodak.reservation.domain.ReserveType;
 import com.padaks.todaktodak.reservation.domain.Status;
 import lombok.AllArgsConstructor;
@@ -24,6 +25,8 @@ public class ReservationSaveReqDto {
     private LocalDate reservationDate;
     private LocalTime reservationTime;
     private boolean isUntact;
+    private MedicalItem medicalItem;
     private Status status;
+    private String field;
     private String message;
 }

--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/service/ReservationService.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/service/ReservationService.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
+
 @Service
 @Slf4j
 @Transactional
@@ -24,5 +26,20 @@ public class ReservationService {
         Reservation reservation = dtoMapper.toReservation(dto);
 
         return reservationRepository.save(reservation);
+    }
+
+//    당일 진료 예약 기능 구현.
+    public Reservation immediateReservation(ReservationSaveReqDto dto){
+        log.info("ReservationSErvice[immediateReservation] : 시작");
+        Reservation reservation = dtoMapper.toReservation(dto);
+        return reservationRepository.save(reservation);
+    }
+
+//    예약 취소 기능
+    public void cancelledReservation(Long id){
+        log.info("ReservationSErvice[cancelledRservation] : 시작");
+        Reservation reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("해당 예약 내역 X "));
+        reservationRepository.delete(reservation);
     }
 }


### PR DESCRIPTION
## 📌 PR 타입

[//]: # ([x] 이렇게하면 체크돼요)
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
[//]: # (ex&#41; 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성)
당일 예약 기능을 구현하였습니다.
> 진료 미리 예약 기능과 당일 예약 기능은 동일한 Dto 를 사용함 
> 각 예약 기능마다 들어가는 값이 다르다고 판단하여 동일한 Dto 를 사용하였습니다. 
만약 다른 Dto 를 써야 할 것 같다면 말씀해 주세요.

예약 취소 기능을 구현하였습니다.
> 예약 취소 같은 경우 예약(Reservation) 테이블과 예약_히스토리(Reservation_History) 테이블 두개를 두기로 하였기 때문에 hard delete 로 디비 상에서 완전히 지워버렸습니다.
현재 설정에서는 아직 Reservation_History 가 존재하지 않기 때문에 삭제만 하지만 
추후 Reservation_History 테이블을 추가하면 해당 테이블에 예약 내역을 추가하는 로직이 추가 될 예정입니다.

## 📷 결과 화면
[//]: # (포스트맨 실행결과를 캡처해주세요)
1. 당일 예약 기능
![image](https://github.com/user-attachments/assets/8fa23245-4e46-47e0-bf14-b58a727b86f9)
> 미리 예약 기능과는 서로 다른 값을 가지고 있기 때문에 null 로 생성되는 값들이 있습니다. 
> 만약 이를 원치 않는다면 DB를 나누는 방법밖에 없다고 생각합니다.
![image](https://github.com/user-attachments/assets/bbb51a3e-f19e-4276-b27b-3a89fc11cbf8)

2. 예약 취소 기능
![image](https://github.com/user-attachments/assets/064e0f6e-96d6-437a-bb8a-2be88bfd35d5)
> 예약 취소시 다음과 같이 200 OK 가 나오고 Pretty 에는 아무것도 안나오는데 이거도 추후 수정하겠습니다.
![image](https://github.com/user-attachments/assets/b5c404d3-c9e0-42aa-90bf-40e9dfb3ad6f)
위 당일 예약 기능의 사진에서 2번 예약이 존재 하였지만 위 사진에서 2번 예약이 사라진 것을 볼 수 있음.

## ✔ 기타 사항
[//]: # (리뷰 받고 싶은 포인트를 적어주세요!)
각 Entity 의 Enum 타입마다 @Enumerated(EnumType.STRING) 을 넣은 것과 안 넣은 것이 공존함
> 이로 인해 DB 상에 번호로 들어가는 이슈가 존재합니다.

수정 예정 사항 :
1. 각 Entity 의 Enum 타입들에 @Enumerated(EnumType.STRING) 추가
2. Reservaiton_History 테이블 추가
3. 예약 MSA 에서 CommonErrorDto , CommonResDto 구현해야 함
> pr 리뷰에 확인 했다는 리뷰 달리면 위의 수정 사항 바로 수정하도록 하겠습니다. & 추가로 수정해야 할 사항 있으면 달아주세요

## 🌳 작업 브랜치
[//]: # (ex&#41;  feat/IS-1)
