### PR TITLE
feat/IS-58 : 병원 + 병원admin 회원가입요청 api, 회원가입승인 api

### DIFF
--- a/member/src/main/java/com/padaks/todaktodak/common/domain/BaseTimeEntity.java
+++ b/member/src/main/java/com/padaks/todaktodak/common/domain/BaseTimeEntity.java
@@ -25,4 +25,8 @@ public class BaseTimeEntity {
     public void setDeletedTimeAt(LocalDateTime deletedAt) {
         this.deletedAt = deletedAt;
     }
+
+    public void acceptHospitalAdmin(){
+        this.deletedAt = null;
+    }
 }

--- a/member/src/main/java/com/padaks/todaktodak/member/controller/MemberController.java
+++ b/member/src/main/java/com/padaks/todaktodak/member/controller/MemberController.java
@@ -93,6 +93,18 @@ public class MemberController {
         return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "의사등록성공", member.getId()),HttpStatus.OK);
     }
 
+    @PostMapping("/hospital-admin/register")
+    public ResponseEntity<?> registerHospitalAdmin(@RequestBody HospitalAdminSaveReqDto dto){
+        Member unAcceptHospitalAdmin = memberService.registerHospitalAdmin(dto);
+        return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "병원 admin 등록성공(미승인)", unAcceptHospitalAdmin.getId()),HttpStatus.OK);
+    }
+
+    @PutMapping("/hospital-admin/accept")
+    public ResponseEntity<?> acceptHospitalAdmin(@RequestBody String email){
+        memberService.acceptHospitalAdmin(email);
+        return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "병원 admin 회원가입 승인완료", null),HttpStatus.OK);
+    }
+
     // 로그인
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody MemberLoginDto loginDto) {

--- a/member/src/main/java/com/padaks/todaktodak/member/domain/Member.java
+++ b/member/src/main/java/com/padaks/todaktodak/member/domain/Member.java
@@ -23,22 +23,28 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
-    //    @Column
-//    private Long familyId;
+
     private String name;
+
     @Column(nullable = false, unique = true)
     private String memberEmail;
+
     //    @Column(nullable = false)
     private String password;
+
     @Column
     private String profileImgUrl;
+
     //    @Column(nullable = false, unique = true)
     private String phoneNumber;
+
     //    @Column(nullable = false)
     private String ssn;
+
     //    @Column(nullable = false)
     @Column(length = 255)
     private Address address;
+
     @ColumnDefault("0")
     private int noShowCount;
 

--- a/member/src/main/java/com/padaks/todaktodak/member/dto/HospitalAdminSaveReqDto.java
+++ b/member/src/main/java/com/padaks/todaktodak/member/dto/HospitalAdminSaveReqDto.java
@@ -1,0 +1,37 @@
+package com.padaks.todaktodak.member.dto;
+
+import com.padaks.todaktodak.member.domain.Member;
+import com.padaks.todaktodak.member.domain.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HospitalAdminSaveReqDto {
+    // 병원 admin 회원가입 request DTO
+    private String adminName; // 병원 admin 이름 (대표자이름)
+
+    private String adminEmail; // 병원 admin 이메일
+
+    private String adminPassword; // 병원 admin 비밀번호
+
+    private String adminPhoneNumber; // 병원 admin 전화번호
+
+    private Long hospitalId; // 저장된 병원 id
+
+    public static Member toEntity(HospitalAdminSaveReqDto dto,
+                                  String encodedPassword){
+        return Member.builder()
+                .name(dto.getAdminName())
+                .memberEmail(dto.getAdminEmail())
+                .password(encodedPassword) // 암호화된 비밀번호
+                .phoneNumber(dto.getAdminPhoneNumber())
+                .hospitalId(dto.getHospitalId())
+                .role(Role.HospitalAdmin)
+                .build();
+    }
+}

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/controller/HospitalController.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/controller/HospitalController.java
@@ -7,6 +7,7 @@ import com.padaks.todaktodak.hospital.service.HospitalService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
@@ -24,6 +25,22 @@ public class HospitalController {
     public ResponseEntity<Object> registerHospital(@ModelAttribute HospitalRegisterReqDto hospitalRegisterReqDto){
         Hospital hospital = hospitalService.registerHospital(hospitalRegisterReqDto);
         return new ResponseEntity<>(new CommonResDto(HttpStatus.CREATED, "병원등록성공", hospital.getId()), HttpStatus.CREATED);
+    }
+
+    // 병원 admin + 병원 등록 (미승인 상태)
+//    @PreAuthorize("hasRole('ROLE_HOSPTIALADMIN')")
+    @PostMapping("/hospital-admin/register")
+    public ResponseEntity<Object> registerHospitalAndAdmin(@RequestBody HospitalAndAdminRegisterReqDto dto){
+        HospitalAndAdminRegisterResDto hospitalAndAdminRegisterResDto
+                = hospitalService.registerHospitalAndAdmin(dto);
+        return new ResponseEntity<>(new CommonResDto(HttpStatus.CREATED, "병원, 병원 admin 등록 성공 (미승인)", hospitalAndAdminRegisterResDto), HttpStatus.CREATED);
+    }
+    // 병원 admin + 병원 승인처리
+    // 병원 : isAccept = true, 병원 admin : deletedAt = null
+    @PutMapping("/accept/{id}")
+    public ResponseEntity<Object> acceptHospital(@PathVariable Long id){
+        hospitalService.acceptHospital(id);
+        return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "병원, 병원 admin 가입 승인처리 성공", null),HttpStatus.OK);
     }
 
     // 병원 detail 조회

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/domain/Hospital.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/domain/Hospital.java
@@ -25,7 +25,9 @@ public class Hospital extends BaseTimeEntity {
     @Column(name = "hospital_id")
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    private String adminEmail; // 병원 admin 이메일
+
+    @Column(nullable = false)
     private String name; // 병원이름
 
     @Column(nullable = false, unique = true)
@@ -50,6 +52,7 @@ public class Hospital extends BaseTimeEntity {
     @Column(precision = 9, scale = 6)
     private BigDecimal longitude; // 경도
 
+    @Column(nullable = false, unique = true)
     private String businessRegistrationInfo; // 사업자등록번호
 
     private String representativeName; // 대표자 이름
@@ -57,6 +60,8 @@ public class Hospital extends BaseTimeEntity {
     private String representativePhoneNumber; // 대표자 핸드폰 번호
 
     private Long untactFee; // 비대면진료비
+
+    private Boolean isAccept; // 가입승인여부
 
     @OneToMany(mappedBy = "hospital", cascade = CascadeType.ALL)
     private List<HospitalOperatingHours> hospitalOperatingHours;
@@ -84,5 +89,9 @@ public class Hospital extends BaseTimeEntity {
         this.representativeName = dto.getRepresentativeName();
         this.representativePhoneNumber = dto.getRepresentativePhoneNumber();
         this.untactFee = dto.getUntactFee();
+    }
+
+    public void acceptHospital(){
+        this.isAccept = true;
     }
 }

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalAdminSaveReqDto.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalAdminSaveReqDto.java
@@ -1,0 +1,34 @@
+package com.padaks.todaktodak.hospital.dto.HospitalDTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HospitalAdminSaveReqDto {
+    // 병원 admin 회원가입 request DTO
+    private String adminName; // 병원 admin 이름 (대표자이름)
+
+    private String adminEmail; // 병원 admin 이메일
+
+    private String adminPassword; // 병원 admin 비밀번호
+
+    private String adminPhoneNumber; // 병원 admin 전화번호
+
+    private Long hospitalId; // 저장된 병원 id
+
+    public static HospitalAdminSaveReqDto fromDto(HospitalAndAdminRegisterReqDto dto,
+                                                  Long hospitalId){
+        return HospitalAdminSaveReqDto.builder()
+                .adminName(dto.getAdminName())
+                .adminEmail(dto.getAdminEmail())
+                .adminPassword(dto.getAdminPassword())
+                .adminPhoneNumber(dto.getAdminPhoneNumber())
+                .hospitalId(hospitalId)
+                .build();
+    }
+}

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalAndAdminRegisterReqDto.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalAndAdminRegisterReqDto.java
@@ -1,0 +1,55 @@
+package com.padaks.todaktodak.hospital.dto.HospitalDTO;
+
+import com.padaks.todaktodak.hospital.domain.Hospital;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HospitalAndAdminRegisterReqDto {
+
+    // 병원 register request DTO
+    private String hospitalName; // 병원이름
+
+    private String address; // 병원주소
+
+    private String dong; // 병원주소(동)
+
+    private BigDecimal latitude; // 위도
+
+    private BigDecimal longitude; //경도
+
+    private String hospitalPhoneNumber; // 병원전화번호
+
+    private String businessRegistrationInfo; // 사업자등록번호
+
+    // 병원 admin 회원가입 request DTO
+    private String adminName; // 병원 admin 이름 (대표자이름)
+
+    private String adminEmail; // 병원 admin 이메일
+
+    private String adminPassword; // 병원 admin 비밀번호
+
+    private String adminPhoneNumber; // 병원 admin 개인 전화번호
+
+
+    public static Hospital toEntity(HospitalAndAdminRegisterReqDto dto){
+        return Hospital.builder()
+                .name(dto.getHospitalName()) // 병원이름
+                .address(dto.getAddress()) // 병원주소
+                .dong(dto.getDong()) // 병원주소(동)
+                .latitude(dto.getLatitude()) // 위도
+                .longitude(dto.getLongitude()) // 경도
+                .phoneNumber(dto.getHospitalPhoneNumber()) // 병원전화번호
+                .businessRegistrationInfo(dto.getBusinessRegistrationInfo()) // 사업자등록번호
+                .adminEmail(dto.getAdminEmail()) // 병원 admin 이메일
+                .isAccept(false) // 개발자admin 승인전까지 승인여부 false
+                .build();
+    }
+}

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalAndAdminRegisterResDto.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalAndAdminRegisterResDto.java
@@ -1,0 +1,53 @@
+package com.padaks.todaktodak.hospital.dto.HospitalDTO;
+
+import com.padaks.todaktodak.hospital.domain.Hospital;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HospitalAndAdminRegisterResDto {
+
+    private Long id; // 병원id
+
+    private String hospitalName; // 병원이름
+
+    private String address; // 병원주소
+
+    private String dong; // 병원주소(동)
+
+    private BigDecimal latitude; // 위도
+
+    private BigDecimal longitude; //경도
+
+    private String hospitalPhoneNumber; // 병원전화번호
+
+    private String businessRegistrationInfo; // 사업자등록번호
+
+    private String hospitalAdminEmail; // 병원 admin 회원 이메일
+
+    private Long hospitalAdminId; // 병원 admin 회원 id
+
+    public static HospitalAndAdminRegisterResDto fromEntity(Hospital hospital,
+                                                            Long hospitalAdminId){
+        return HospitalAndAdminRegisterResDto.builder()
+                .id(hospital.getId())
+                .hospitalName(hospital.getName())
+                .address(hospital.getAddress())
+                .dong(hospital.getDong())
+                .latitude(hospital.getLatitude())
+                .longitude(hospital.getLongitude())
+                .hospitalPhoneNumber(hospital.getPhoneNumber())
+                .businessRegistrationInfo(hospital.getBusinessRegistrationInfo())
+                .hospitalAdminEmail(hospital.getAdminEmail())
+                .hospitalAdminId(hospitalAdminId)
+                .build();
+    }
+
+}

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalDetailResDto.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalDTO/HospitalDetailResDto.java
@@ -48,6 +48,8 @@ public class HospitalDetailResDto {
 
     private Long untactFee; // 비대면진료비
 
+    private Boolean isAccept; // 가입승인여부
+
     public static HospitalDetailResDto fromEntity(Hospital hospital,
                                                   Long standby,
                                                   String distance
@@ -70,6 +72,7 @@ public class HospitalDetailResDto {
                 .representativeName(hospital.getRepresentativeName())
                 .representativePhoneNumber(hospital.getRepresentativePhoneNumber())
                 .untactFee(hospital.getUntactFee())
+                .isAccept(hospital.getIsAccept())
                 .build();
     }
 

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/repository/HospitalRepository.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/repository/HospitalRepository.java
@@ -13,10 +13,17 @@ import static com.padaks.todaktodak.common.exception.exceptionType.HospitalExcep
 @Repository
 public interface HospitalRepository extends JpaRepository<Hospital, Long> {
 
-    // deleteAt이 null인 객체 찾음(삭제되지 않은 객체)
-    Optional<Hospital> findByIdAndDeletedAtIsNull(Long id);
+    // deleteAt이 null, isAccept가 true인 객체 찾음(삭제되지 않은 객체)
+    Optional<Hospital> findByIdAndDeletedAtIsNullAndIsAcceptIsTrue(Long id);
 
     default Hospital findByIdOrThrow(Long id) {
+        return findByIdAndDeletedAtIsNullAndIsAcceptIsTrue(id)
+                .orElseThrow(() -> new BaseException(HOSPITAL_NOT_FOUND));
+    }
+
+    // deleteAt이 null인 병원 (삭제되지 않은 병원)
+    Optional<Hospital> findByIdAndDeletedAtIsNull(Long id);
+    default Hospital findByIdDeletedAtIsNullOrThrow(Long id) {
         return findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new BaseException(HOSPITAL_NOT_FOUND));
     }
@@ -25,5 +32,5 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
     List<Hospital> findByDeletedAtIsNull();
 
     // 삭제되지 않은 병원리스트 중 '~~동'으로 병원찾기
-    List<Hospital> findByDongAndDeletedAtIsNull(String dong);
+    List<Hospital> findByDongAndDeletedAtIsNullAndIsAcceptIsTrue(String dong);
 }

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/service/HospitalService.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/service/HospitalService.java
@@ -1,5 +1,7 @@
 package com.padaks.todaktodak.hospital.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.padaks.todaktodak.common.dto.CommonResDto;
 import com.padaks.todaktodak.common.exception.BaseException;
 import com.padaks.todaktodak.common.exception.exceptionType.HospitalExceptionType;
 import com.padaks.todaktodak.hospital.domain.Hospital;
@@ -9,7 +11,6 @@ import com.padaks.todaktodak.util.DistanceCalculator;
 import com.padaks.todaktodak.util.S3ClientFileUpload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,6 +28,7 @@ public class HospitalService {
     private final HospitalRepository hospitalRepository;
     private final S3ClientFileUpload s3ClientFileUpload;
     private final DistanceCalculator distanceCalculator;
+    private final MemberFeign memberFeign;
 
     // 병원등록
     public Hospital registerHospital(HospitalRegisterReqDto dto){
@@ -40,6 +42,29 @@ public class HospitalService {
         Hospital hospital = dto.toEntity(dto, imageUrl);
 
         return hospitalRepository.save(hospital); // Hospital 저장
+    }
+
+    // 병원등록 + 병원 admin 등록(Member에게 feign 요청)
+    // 회원가입 승인요청 -> 병원데이터 등록, 승인여부 false (미승인)
+    public HospitalAndAdminRegisterResDto registerHospitalAndAdmin(HospitalAndAdminRegisterReqDto dto){
+
+        Hospital hospital = hospitalRepository.save(dto.toEntity(dto)); // 병원 + 병원admin DTO -> 병원 엔티티로 조립
+        HospitalAdminSaveReqDto adminSaveReqDto = HospitalAdminSaveReqDto.fromDto(dto, hospital.getId()); // 병원admin(Member) 등록 request DTO
+
+        CommonResDto commonResDto = memberFeign.registerHospitalAdmin(adminSaveReqDto);
+        ObjectMapper objectMapper = new ObjectMapper();
+        Long hospitalAdminId = objectMapper.convertValue(commonResDto.getResult(), Long.class);
+
+        System.out.println("feign : 병원admin 회원 등록성공 회원id " + hospitalAdminId);
+
+        return HospitalAndAdminRegisterResDto.fromEntity(hospital, hospitalAdminId);
+    }
+
+    // 병원 승인
+    public void acceptHospital(Long id){
+        Hospital hospital = hospitalRepository.findByIdOrThrow(id);
+        hospital.acceptHospital(); // isAccept = true (승인처리)
+        memberFeign.acceptHospitalAdmin(hospital.getAdminEmail()); // 해당병원 admin deletedAt = null 처리 (존재하는 회원 처리)
     }
 
     // 병원 detail 조회

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/service/HospitalService.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/service/HospitalService.java
@@ -62,7 +62,7 @@ public class HospitalService {
 
     // 병원 승인
     public void acceptHospital(Long id){
-        Hospital hospital = hospitalRepository.findByIdOrThrow(id);
+        Hospital hospital = hospitalRepository.findByIdDeletedAtIsNullOrThrow(id);
         hospital.acceptHospital(); // isAccept = true (승인처리)
         memberFeign.acceptHospitalAdmin(hospital.getAdminEmail()); // 해당병원 admin deletedAt = null 처리 (존재하는 회원 처리)
     }
@@ -113,7 +113,7 @@ public class HospitalService {
                                                     BigDecimal latitude,
                                                     BigDecimal longitude){
 
-        List<Hospital> hospitalList = hospitalRepository.findByDongAndDeletedAtIsNull(dong);
+        List<Hospital> hospitalList = hospitalRepository.findByDongAndDeletedAtIsNullAndIsAcceptIsTrue(dong);
         List<HospitalListResDto> dtoList = new ArrayList<>();
         String distance = null;
         Long standby = null; // 실시간 대기자 수 : 이후 redis 붙일예정

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/service/MemberFeign.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/service/MemberFeign.java
@@ -1,0 +1,19 @@
+package com.padaks.todaktodak.hospital.service;
+
+import com.padaks.todaktodak.common.config.FeignConfig;
+import com.padaks.todaktodak.common.dto.CommonResDto;
+import com.padaks.todaktodak.hospital.dto.HospitalDTO.HospitalAdminSaveReqDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+// eureka에 등록된 name
+@FeignClient(name="member-service", configuration = FeignConfig.class)
+public interface MemberFeign {
+    @PostMapping(value = "/member/hospital-admin/register")
+    CommonResDto registerHospitalAdmin(@RequestBody HospitalAdminSaveReqDto dto);
+
+    @PutMapping("/member/hospital-admin/accept")
+    void acceptHospitalAdmin(@RequestBody String email);
+}


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 병원 예약 생성 API 작성 -->
### 병원 admin 회원가입 + 병원등록
 병원admin 회원가입 시 병원등록 정보까지 같이 받아서 병원admin, 병원 동시 생성
단, 병원admin(member)는 deletedAt = LocalDateTime.now() 처리해서 데이터는 생성했지만 존재하지 않는 회원으로 간주되게 함
병원 데이터는 isAccept = false 로 생성해서 승인받지 않은 병원으로 처리함

### 병원admin + 병원 회원가입 승인
- 병원admin의 deletedAt = null 처리
- 병원에는 isAccept = true 처리

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
## 병원생성 + 병원admin 생성
### 포스트맨 결과
<img width="654" alt="image" src="https://github.com/user-attachments/assets/ec287915-8070-4fef-9c2c-b92cee567189">

### DB 결과 
**Hospital**
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/987d8002-8c8f-4155-a1da-d5ae55debdcc">
<img width="766" alt="image" src="https://github.com/user-attachments/assets/51023362-e228-4030-80cb-a8385eca9568">
isAccept = false 상태(아직 미승인)

**Member**
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/ac1c6762-6ace-4139-8f44-40607056989c">
<img width="876" alt="image" src="https://github.com/user-attachments/assets/154c1c3c-00e7-4816-a716-9632308d888f">
member의 deletedAt = LocalDateTime.now() 넣어서 없는 회원처럼 간주되게 함

## 병원 + 병원admin 회원가입 승인처리
### 포스트맨 결과
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/6fd27ef1-3aba-42c2-aab6-b99091bd5a39">

### DB 결과
**Member**
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/7bf206e4-8e42-4801-9f55-10204347616e">
deletedAt = null 처리 -> 있는 회원으로 간주

**Hospital**
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/5876782c-37d1-4bcb-a722-3993a0591021">
isAccept = true(1) 처리

### 병원 detail 조회
<img width="725" alt="image" src="https://github.com/user-attachments/assets/3c2d5c77-75c2-421c-b22b-ef971c4f2375">

### 병원 수정
<img width="842" alt="image" src="https://github.com/user-attachments/assets/9708bf32-82c6-4323-a978-4b39c04f0d1e">

## 병원리스트 : 승인된 병원만 조회가능하도록 수정
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/a136a4b0-fa7a-4402-b386-754e0e724a5a">
병원1번만 승인함, 4번은 미승인 상태

<img width="700" alt="image" src="https://github.com/user-attachments/assets/385825d7-89ae-415d-ac5d-4d45f83dc612">
병원리스트 조회시 승인된 1번만 나옴


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
이후 Member 필드에 이메일 승인여부 필드 추가하면 다시 수정할예정
충돌날까봐 Hospital 엔티티에만 승인여부 필드 추가해서 api 구현했습니다.

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-58