### PR TITLE
#136 feat : 예약 시간 30분전 Kafka 메시지 전송 로직 구현 (알림 수신 로직 구현 X)

### DIFF
--- a/member/src/main/java/com/padaks/todaktodak/notification/dto/ReserveBeforeNotifyResDto.java
+++ b/member/src/main/java/com/padaks/todaktodak/notification/dto/ReserveBeforeNotifyResDto.java
@@ -1,0 +1,17 @@
+package com.padaks.todaktodak.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class ReserveBeforeNotifyResDto {
+    private String doctorName;
+    private String reservationTime;
+    private String hospitalName;
+    private String reservationDate;
+    private String message;
+    private String memberEmail;
+}

--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/repository/ReservationRepository.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/repository/ReservationRepository.java
@@ -3,9 +3,11 @@ package com.padaks.todaktodak.reservation.repository;
 import com.padaks.todaktodak.reservation.domain.Reservation;
 import com.padaks.todaktodak.reservation.domain.ReserveType;
 import com.padaks.todaktodak.reservation.domain.Status;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.*;
@@ -33,4 +35,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
 
     List<Reservation> findAllByReservationDateAndReservationTime(LocalDate localDate, LocalTime localTime);
+
+//    JQPL 을 이용한 당일의 해당 시간 스케줄예약 찾는 로직
+    @Query("SELECT res FROM Reservation res WHERE res.reservationTime = :targetTime AND res.reservationDate = :targetDate")
+    List<Reservation> findReservationByAtSpecificTimeAndSpecificDate(@Param("targetTime") LocalTime targetTime,
+                                                      @Param("targetDate") LocalDate targetDate);
 }

--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/service/ReservationService.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/service/ReservationService.java
@@ -260,8 +260,7 @@ public class ReservationService {
             messageDate.put("hospitalName", res.getHospital().getName());
             messageDate.put("doctorName", res.getDoctorName());
             messageDate.put("message", "예약 30분 전입니다");
-            log.info(res.getId().toString());
-            kafkaTemplate.send("reservation-before-notify", messageDate);
+            kafkaTemplate.send("scheduled-reservation-before-notify", messageDate);
         }
     }
 

--- a/reservation/src/main/java/com/padaks/todaktodak/reservation/service/ReservationService.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/reservation/service/ReservationService.java
@@ -244,15 +244,20 @@ public class ReservationService {
         return member;
     }
 
-    @Scheduled(cron = "0 0,30 9-12,13-22 * * *")
+//    예약 30분 전에 알림 보내는 스케줄 로직
+    @Scheduled(cron = "0 0,30 8-12,13-22 * * *")
     public void notifyBeforeReservation(){
+//        오늘 날짜
         LocalDate targetDate = LocalDate.now();
-
+//        현재 시간 스케줄로 인해 9시~12시, 13시~22시 0분,30분 고정
         LocalTime currentTime = LocalTime.now();
+//        현재 시간으로 부터 30분 이후 ex) 09:00 -> 09:30, 10:30 -> 11:00
         LocalTime targetTime = currentTime.plusMinutes(30);
-
+//        오늘 날짜와 현재 시간을 기준으로 예약을 찾아오는 로직 (JQPL 사용함)
         List<Reservation> reservations = reservationRepository.findReservationByAtSpecificTimeAndSpecificDate(targetTime,targetDate);
+
         for(Reservation res : reservations){
+//            카프카로 전송해줄 메시지 생성
             Map<String, String> messageDate = new HashMap<>();
             messageDate.put("memberEmail", res.getMemberEmail());
             messageDate.put("reservationDate", res.getReservationDate().toString());
@@ -260,6 +265,7 @@ public class ReservationService {
             messageDate.put("hospitalName", res.getHospital().getName());
             messageDate.put("doctorName", res.getDoctorName());
             messageDate.put("message", "예약 30분 전입니다");
+//            카프카로 메시지 전송.
             kafkaTemplate.send("scheduled-reservation-before-notify", messageDate);
         }
     }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 병원 예약 생성 API 작성 -->
1. 예약 시간 30분전에 스케줄러로 Kafka 메시지 전송
2. Kafka 메시지 수신 시 사용자에게 알림 전송 로직

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
- 총 다른 날짜 같은 시간의 예약이 3개 존재 but 오늘 날짜의 해당 시간의 예약만 Kafka 메시지 전송 성공(5번 예약)
![image](https://github.com/user-attachments/assets/aa8334f6-3c40-4163-9960-c0d20fcebf34)
![image](https://github.com/user-attachments/assets/bac74c54-04fe-4b68-8c1b-21d740fbe1ba)
- Kafka 메시지 수신 확인
![image](https://github.com/user-attachments/assets/e9a1d64b-96ef-4c0a-a53a-61312a1d5780)

- Kafka 메시지 수신 후 후처리 로직
  - 미구현 
- 사용자에게 알림 전송
  - 미구현


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
close #136 
