### PR TITLE
feat: 병원 디테일 authentication 객체로 보안 강화 -> 오직 해당 멤버만 병원 관리  페이지 접근 가능

### DIFF
--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/controller/HospitalController.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/controller/HospitalController.java
@@ -13,6 +13,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.math.BigDecimal;
@@ -55,6 +58,17 @@ public class HospitalController {
                                                     @RequestParam BigDecimal latitude,
                                                     @RequestParam BigDecimal longitude) {
         HospitalDetailResDto hospitalDetail = hospitalService.getHospitalDetail(id, latitude, longitude);
+        return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "병원정보 조회성공", hospitalDetail), HttpStatus.OK);
+    }
+
+    // 병원 어드민 detail 조회
+    @GetMapping("/admin/detail")
+    public ResponseEntity<Object> hospitalAdminDetail() {
+        // 인증된 authentication 객체에서 해당 member의 email을 추출해서 인가된 사용자만이 접근할 수 있도록
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        String adminEmail = userDetails.getUsername();
+        HospitalAdminDetailResDto hospitalDetail = hospitalService.hospitalAdminDetail(adminEmail);
         return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "병원정보 조회성공", hospitalDetail), HttpStatus.OK);
     }
 

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalAdminDetailResDto.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalAdminDetailResDto.java
@@ -1,0 +1,97 @@
+package com.padaks.todaktodak.hospital.dto;
+
+import com.padaks.todaktodak.common.enumdir.DayOfHoliday;
+import com.padaks.todaktodak.hospital.domain.Hospital;
+import com.padaks.todaktodak.hospitaloperatinghours.domain.HospitalOperatingHours;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HospitalAdminDetailResDto {
+
+    //=== 병원기본정보 ===
+
+    private Long id; // 병원 id
+
+
+    private String name; // 병원이름
+
+    private String address; // 병원주소
+
+    private String dong; // 병원주소(동)
+
+    private String phoneNumber; // 병원번호
+
+    private String hospitalImageUrl; // 병원사진
+
+    private String description; // 병원소개
+
+    private String notice; // 병원공지
+
+    private String keywords; // 병원 keywords
+
+    private String businessRegistrationInfo; // 사업자등록번호
+
+    private String representativeName; // 대표자 이름
+
+    private String representativePhoneNumber; // 대표자 핸드폰 번호
+
+    private Long untactFee; // 비대면진료비
+
+    private Boolean isAccept; // 가입승인여부
+
+    // === 병원 리뷰정보 ===
+    private Double averageRating; // 병원 평균 평점
+
+    private Long reviewCount; // 병원 리뷰 개수
+
+    private BigDecimal latitude; // 위도
+
+    private BigDecimal longitude; //경도
+
+
+    public static HospitalAdminDetailResDto fromEntity(Hospital hospital,
+                                                       Double averageRating,
+                                                       Long reviewCount
+                                                  ){
+
+        // 평균평점 소수점 첫째 자리까지 반올림 처리
+        if (averageRating != null) {
+            averageRating = Math.round(averageRating * 10) / 10.0;
+        }
+
+        // 병원 영업시간 리스트 순회
+
+        return HospitalAdminDetailResDto.builder()
+                .id(hospital.getId())
+                .name(hospital.getName())
+                .address(hospital.getAddress())
+                .dong(hospital.getDong())
+                .phoneNumber(hospital.getPhoneNumber())
+                .hospitalImageUrl(hospital.getHospitalImageUrl())
+                .description(hospital.getDescription())
+                .notice(hospital.getNotice())
+                .latitude(hospital.getLatitude())
+                .longitude(hospital.getLongitude())
+                .keywords(hospital.getKeywords())
+                .businessRegistrationInfo(hospital.getBusinessRegistrationInfo())
+                .representativeName(hospital.getRepresentativeName())
+                .representativePhoneNumber(hospital.getRepresentativePhoneNumber())
+                .untactFee(hospital.getUntactFee())
+                .isAccept(hospital.getIsAccept())
+                .averageRating(averageRating)  // 평균 평점
+                .reviewCount(reviewCount)  // 리뷰 개수
+                .build();
+    }
+
+}

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalUpdateReqDto.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/dto/HospitalUpdateReqDto.java
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 @Builder
 public class HospitalUpdateReqDto {
 
-    private Long id; // 병원 id
+//    private Long id; // 병원 id
 
     private String name; // 병원이름
 

--- a/reservation/src/main/java/com/padaks/todaktodak/hospital/repository/HospitalRepository.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospital/repository/HospitalRepository.java
@@ -39,4 +39,7 @@ public interface HospitalRepository extends JpaRepository<Hospital, Long> {
 
     Page<Hospital> findByRepresentativeNameContainingOrNameContainingOrAdminEmailContaining(
             String representativeName, String name, String adminEmail, Pageable pageable);
+
+    Optional<Hospital> findByAdminEmail(String adminEmail);
+
 }

--- a/reservation/src/main/java/com/padaks/todaktodak/hospitaloperatinghours/controller/HospitalOperatingHoursController.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospitaloperatinghours/controller/HospitalOperatingHoursController.java
@@ -7,6 +7,9 @@ import com.padaks.todaktodak.hospitaloperatinghours.service.HospitalOperatingHou
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,6 +33,16 @@ public class HospitalOperatingHoursController {
     @GetMapping("/detail/{hospitalId}")
     public ResponseEntity<Object> getOperatingHours(@PathVariable Long hospitalId){
         List<HospitalOperatingHoursResDto> operatingHoursList = hospitalOperatingHoursService.getOperatingHoursByHospitalId(hospitalId);
+        return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "병원영업시간 조회 성공", operatingHoursList),HttpStatus.OK);
+    }
+
+    // 병원 영업시간 리스트 조회
+    @GetMapping("/admin/detail")
+    public ResponseEntity<Object> adminOperatingHours(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        String adminEmail = userDetails.getUsername();
+        List<HospitalOperatingHoursResDto> operatingHoursList = hospitalOperatingHoursService.adminOperatingHoursByHospitalId(adminEmail);
         return new ResponseEntity<>(new CommonResDto(HttpStatus.OK, "병원영업시간 조회 성공", operatingHoursList),HttpStatus.OK);
     }
 

--- a/reservation/src/main/java/com/padaks/todaktodak/hospitaloperatinghours/repository/HospitalOperatingHoursRepository.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospitaloperatinghours/repository/HospitalOperatingHoursRepository.java
@@ -29,4 +29,6 @@ public interface HospitalOperatingHoursRepository extends JpaRepository<Hospital
     // 병원에 속한 모든 영업시간을 가져옴
     List<HospitalOperatingHours> findAllByHospital(Hospital hospital);
 
+
+
 }

--- a/reservation/src/main/java/com/padaks/todaktodak/hospitaloperatinghours/service/HospitalOperatingHoursService.java
+++ b/reservation/src/main/java/com/padaks/todaktodak/hospitaloperatinghours/service/HospitalOperatingHoursService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -55,6 +56,17 @@ public class HospitalOperatingHoursService {
     // 특정병원의 모든 영업시간 리스트 조회
     public List<HospitalOperatingHoursResDto> getOperatingHoursByHospitalId(Long hospitalId) {
         List<HospitalOperatingHours> operatingHoursList = hospitalOperatingHoursRepository.findByHospitalId(hospitalId);
+
+        return operatingHoursList.stream()
+                .map(HospitalOperatingHoursResDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public List<HospitalOperatingHoursResDto> adminOperatingHoursByHospitalId(String adminEmail) {
+        Hospital hospital = hospitalRepository.findByAdminEmail(adminEmail)
+                .orElseThrow(() -> new EntityNotFoundException("해당 병원의 관리자가 아닙니다."));
+
+        List<HospitalOperatingHours> operatingHoursList = hospitalOperatingHoursRepository.findByHospitalId(hospital.getId());
 
         return operatingHoursList.stream()
                 .map(HospitalOperatingHoursResDto::fromEntity)


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 병원 예약 생성 API 작성 -->
병원 관리자의 병원 디테일 api 추가
병원 디테일 조회 및 접근은 해당 병원 관리자만 가능하도록 설정(즉, id나 다른 값을 받지 않고 오직, authentication 객체에서 인가를 거침)
마찬가지로 병원 정보 수정도 해당 관리자만 수정 가능

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
<img width="1512" alt="스크린샷 2024-10-22 오후 4 00 25" src="https://github.com/user-attachments/assets/46cee71c-8c84-4ad7-b8b6-9f1149a26ec4">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-273