### PR TITLE
feat: postBatch에서 create모드시 redis에서 없는 key 조회하는 에러 해결

### DIFF
--- a/community/src/main/java/com/padaks/todaktodak/post/service/PostBatchService.java
+++ b/community/src/main/java/com/padaks/todaktodak/post/service/PostBatchService.java
@@ -34,11 +34,18 @@ public class PostBatchService {
                     Long postId = extractPostId(key);
                     Long views = getPostViewsFromRedis(postId);
                     if (views != null && views > 0) {
+//                        Post post = postRepository.findById(postId)
+//                                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
                         Post post = postRepository.findById(postId)
-                                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
-                        post.updateViewCount(views);  // Post 엔티티에 조회수 반영 메서드
-                        postRepository.save(post);   // DB에 저장
-//                        redisTemplate.delete(key);  // Redis에서 삭제 (초기화)
+                                .orElse(null);  // 게시글이 없을 때 null 반환
+                        if (post != null) {
+                            post.updateViewCount(views);
+                            postRepository.save(post);
+                        } else {
+                            // 게시글이 없는 경우 Redis에서 해당 키 삭제
+                            System.out.println("Post not found: " + postId + ". Deleting Redis key: " + key);
+                            redisTemplate.delete(key);
+                        }
                     }
                 }
 
@@ -47,10 +54,15 @@ public class PostBatchService {
                     Long likes = getPostLikesFromRedis(postId);
                     if (likes != null && likes > 0) {
                         Post post = postRepository.findById(postId)
-                                .orElseThrow(() -> new IllegalArgumentException("Post not found: " + postId));
-                        post.updateLikeCount(likes);  // Post 엔티티에 좋아요 수 반영 메서드
-                        postRepository.save(post);   // DB에 저장
-//                        redisTemplate.delete(key);  // Redis에서 삭제 (초기화)
+                                .orElse(null);  // 게시글이 없을 때 null 반환
+                        if (post != null) {
+                            post.updateLikeCount(likes);
+                            postRepository.save(post);
+                        } else {
+                            // 게시글이 없는 경우 Redis에서 해당 키 삭제
+                            System.out.println("Post not found: " + postId + ". Deleting Redis key: " + key);
+                            redisTemplate.delete(key);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 병원 예약 생성 API 작성 -->
- 커뮤니티 postBatchService에서 
- create모드시 redis에만 있고 db에 없는 post를 찾을 경우 발생하는 예외를 적절히 처리하여, 문제없이 실행할 수 있게 변경

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
<img width="1512" alt="스크린샷 2024-10-23 오후 3 31 49" src="https://github.com/user-attachments/assets/c6ab5eaf-3304-4609-839b-8f8ba899fa23">


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/IS-289